### PR TITLE
Use asyncio event for `Node.is_started`

### DIFF
--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -142,8 +142,6 @@ DIAL_RETRY_COUNT = 5
 
 class Node(BaseService):
 
-    _is_started: bool = False
-
     key_pair: KeyPair
     listen_ip: str
     listen_port: int
@@ -212,11 +210,8 @@ class Node(BaseService):
 
         self.handshaked_peers = set()
 
+        self.event_is_started = asyncio.Event()
         self.run_task(self.start())
-
-    @property
-    def is_started(self) -> bool:
-        return self._is_started
 
     async def _run(self) -> None:
         self.logger.info("libp2p node %s is up", self.listen_maddr)
@@ -235,7 +230,7 @@ class Node(BaseService):
         await self.pubsub.subscribe(PUBSUB_TOPIC_BEACON_ATTESTATION)
         self._setup_topic_validators()
 
-        self._is_started = True
+        self.event_is_started.set()
 
     def _setup_topic_validators(self) -> None:
         self.pubsub.set_topic_validator(

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -212,9 +212,7 @@ class BCCReceiveServer(BaseService):
         self.run_daemon_task(self._handle_head_slot_requests())
         self.run_daemon_task(self._handle_head_root_requests())
 
-        while not self.p2p_node.is_started:
-            await self.sleep(0.5)
-
+        await self.wait(self.p2p_node.event_is_started.wait())
         self.logger.info("BCCReceiveServer up")
 
         self.run_daemon_task(self._handle_beacon_attestation_loop())


### PR DESCRIPTION
### How was it fixed?
Just a minor change but it seems to fix the problem of not running the `_handle_head_slot_requests` loop (works on my laptop).

https://github.com/ethereum/trinity/pull/1105
[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()